### PR TITLE
Fix issue when using Safari during local development on Mac OSX.

### DIFF
--- a/js/bimserverclient.js
+++ b/js/bimserverclient.js
@@ -1,6 +1,6 @@
-if (typeof XMLHttpRequest != "function") {
-	var XMLHttpRequest = require("xhr2");
-}
+// if (typeof XMLHttpRequest != "function") {
+// 	var XMLHttpRequest = require("xhr2");
+// }
 
 //var BimServerApiPromise = null;
 var ifc2x3tc1 = null;


### PR DESCRIPTION
For information, was not reproduced using Chrome, as the "require" is not executed when testing with Chrome.