### PR TITLE
Fix: model.getAllOfType correctly loads all subTypes

### DIFF
--- a/model.js
+++ b/model.js
@@ -782,7 +782,7 @@ export default class Model {
 			};
 
 			types.forEach((type) => {
-				if (this.loadedTypes[type] != null) {
+				if (this.loadedTypes[type] && Object.getOwnPropertyNames(this.loadedTypes[type]).length !== 0) {
 					for (let oid in this.loadedTypes[type]) {
 						callback(this.loadedTypes[type][oid]);
 					}
@@ -806,32 +806,30 @@ export default class Model {
 							serializerOid: serializer.oid
 						});
 						this.bimServerApi.getJson(url, null, (data) => {
-							if (this.loadedTypes[type] == null) {
-								this.loadedTypes[type] = {};
-							}
-							data.objects.some((object) => {
-								if (this.objects[object._i] != null) {
+							data.objects.forEach((object) => {
+								if (this.objects[object._i]) {
 									// Hmm we are doing a query on type, but some objects have already loaded, let's use those instead
 									const wrapper = this.objects[object._i];
 									if (wrapper.object._s == 1) {
-										if (wrapper.isA(type)) {
-											this.loadedTypes[type][object._i] = wrapper;
-											return callback(wrapper);
+										if (wrapper.isA(object._t)) {
+											this.loadedTypes[object._t][object._i] = wrapper;
+											callback(wrapper);
 										}
 									} else {
 										// Replace the value with something that's LOADED
 										wrapper.object = object;
-										if (wrapper.isA(type)) {
-											this.loadedTypes[type][object._i] = wrapper;
-											return callback(wrapper);
+										if (wrapper.isA(object._t)) {
+											this.loadedTypes[object._t][object._i] = wrapper;
+											callback(wrapper);
 										}
 									}
 								} else {
 									const wrapper = this.createWrapper(object, object._t);
 									this.objects[object._i] = wrapper;
-									if (wrapper.isA(type) && object._s == 1) {
-										this.loadedTypes[type][object._i] = wrapper;
-										return callback(wrapper);
+									if (object._s == 1) {
+										if (!this.loadedTypes[object._t]) { this.loadedTypes[object._t] = {} }
+										this.loadedTypes[object._t][object._i] = wrapper;
+										callback(wrapper);
 									}
 								}
 							});


### PR DESCRIPTION
In some cases the test

```
this.loadedTypes[type] != null
```

isn't enough, because `loadedTypes` is initialized with `{}` and then the call with `includeAllSubTypes = true` doesn't load all of the subtypes.

I've encountered this issue while calling `getAllOfType("IfcProduct", true, function () { /* ...*/})` on the attached IFC file, using a `Model` object preloaded with the `ifc2x3tc1` preload query.

[quattromura_rev_2.ifc.zip](https://github.com/opensourceBIM/BIMserver-JavaScript-API/files/1841914/quattromura_rev_2.ifc.zip)

Also this pull request loads the objects in the proper `loadedTypes` dictionary.







